### PR TITLE
feat(document): add endpoint to find documents by user id with option…

### DIFF
--- a/src/modules/document/application/use-cases/find-documents-by-user-id.use-case.spec.ts
+++ b/src/modules/document/application/use-cases/find-documents-by-user-id.use-case.spec.ts
@@ -1,0 +1,140 @@
+import { Test, TestingModule } from "@nestjs/testing";
+import { FindDocumentsByUserIdUseCase } from "./find-documents-by-user-id.use-case";
+import { HttpStatus } from "@nestjs/common";
+
+describe("FindDocumentsByUserIdUseCase", () => {
+    let useCase: FindDocumentsByUserIdUseCase;
+    let mockDocumentRepository: any;
+
+    beforeEach(async () => {
+        mockDocumentRepository = {
+            findDocumentsByUserId: jest.fn(),
+        };
+
+        const module: TestingModule = await Test.createTestingModule({
+            providers: [
+                FindDocumentsByUserIdUseCase,
+                {
+                    provide: "IDocumentRepository",
+                    useValue: mockDocumentRepository,
+                },
+            ],
+        }).compile();
+
+        useCase = module.get<FindDocumentsByUserIdUseCase>(FindDocumentsByUserIdUseCase);
+    });
+
+    it("should be defined", () => {
+        expect(useCase).toBeDefined();
+    });
+
+    it("should return empty array if userId is missing", async () => {
+        const result = await useCase.execute("", {
+            startDate: "2026-01-01",
+            endDate: "2026-12-31",
+            veterinarianName: "John Doe",
+            documentName: "Report",
+        });
+
+        expect(mockDocumentRepository.findDocumentsByUserId).not.toHaveBeenCalled();
+        expect(result).toEqual({
+            statusCode: HttpStatus.OK,
+            message: "Documents retrieved successfully",
+            data: [],
+        });
+    });
+
+    it("should return empty array if all queries are missing", async () => {
+        const result = await useCase.execute("user-123", {});
+
+        expect(mockDocumentRepository.findDocumentsByUserId).not.toHaveBeenCalled();
+        expect(result).toEqual({
+            statusCode: HttpStatus.OK,
+            message: "Documents retrieved successfully",
+            data: [],
+        });
+    });
+
+    it("should call repository if only documentName is passed", async () => {
+        const mockDocs = [{ id: "doc-1", title: "Report 1", fileUrl: "http://example.com/1.pdf" }];
+        mockDocumentRepository.findDocumentsByUserId.mockResolvedValue(mockDocs);
+
+        const result = await useCase.execute("user-123", {
+            documentName: "Report",
+        });
+
+        expect(mockDocumentRepository.findDocumentsByUserId).toHaveBeenCalledWith("user-123", {
+            startDate: undefined,
+            endDate: undefined,
+            veterinarianName: undefined,
+            documentName: "Report",
+        });
+        expect(result).toEqual({
+            statusCode: HttpStatus.OK,
+            message: "Documents retrieved successfully",
+            data: mockDocs,
+        });
+    });
+
+    it("should call repository if only veterinarianName is passed", async () => {
+        const mockDocs = [{ id: "doc-2", title: "Doc 2", fileUrl: "http://example.com/2.pdf" }];
+        mockDocumentRepository.findDocumentsByUserId.mockResolvedValue(mockDocs);
+
+        const result = await useCase.execute("user-123", {
+            veterinarianName: "Dr. House",
+        });
+
+        expect(mockDocumentRepository.findDocumentsByUserId).toHaveBeenCalledWith("user-123", {
+            startDate: undefined,
+            endDate: undefined,
+            veterinarianName: "Dr. House",
+            documentName: undefined,
+        });
+        expect(result).toEqual({
+            statusCode: HttpStatus.OK,
+            message: "Documents retrieved successfully",
+            data: mockDocs,
+        });
+    });
+
+    it("should return empty array if only invalid date is passed", async () => {
+        const result = await useCase.execute("user-123", {
+            startDate: "not-a-date",
+        });
+
+        expect(mockDocumentRepository.findDocumentsByUserId).not.toHaveBeenCalled();
+        expect(result).toEqual({
+            statusCode: HttpStatus.OK,
+            message: "Documents retrieved successfully",
+            data: [],
+        });
+    });
+
+    it("should call repository if all queries are passed", async () => {
+        const mockDocs = [
+            { id: "doc-1", title: "Report 1", fileUrl: "http://example.com/1.pdf" }
+        ];
+        mockDocumentRepository.findDocumentsByUserId.mockResolvedValue(mockDocs);
+
+        const queries = {
+            startDate: "2026-01-01",
+            endDate: "2026-12-31",
+            veterinarianName: "John Doe",
+            documentName: "Report",
+        };
+
+        const result = await useCase.execute("user-123", queries);
+
+        expect(mockDocumentRepository.findDocumentsByUserId).toHaveBeenCalledWith("user-123", {
+            startDate: new Date("2026-01-01"),
+            endDate: new Date("2026-12-31"),
+            veterinarianName: "John Doe",
+            documentName: "Report",
+        });
+        expect(result).toEqual({
+            statusCode: HttpStatus.OK,
+            message: "Documents retrieved successfully",
+            data: mockDocs,
+        });
+    });
+});

--- a/src/modules/document/application/use-cases/find-documents-by-user-id.use-case.ts
+++ b/src/modules/document/application/use-cases/find-documents-by-user-id.use-case.ts
@@ -1,0 +1,85 @@
+import { ResponseDto } from "@/common/domain/dto";
+import { DocumentModel } from "@document/domain/models";
+import type { IDocumentRepository } from "@document/domain/ports/document.repository";
+import { HttpStatus, Inject, Injectable } from "@nestjs/common";
+
+@Injectable()
+export class FindDocumentsByUserIdUseCase {
+    constructor(
+        @Inject("IDocumentRepository")
+        private readonly documentRepository: IDocumentRepository,
+    ) { }
+
+    async execute(
+        userId: string,
+        queries: {
+            startDate?: string;
+            endDate?: string;
+            veterinarianName?: string;
+            documentName?: string;
+        }
+    ): Promise<ResponseDto<DocumentModel[]>> {
+        const { startDate, endDate, veterinarianName, documentName } = queries;
+
+        const hasStartDate = !!startDate?.trim();
+        const hasEndDate = !!endDate?.trim();
+        const hasVetName = !!veterinarianName?.trim();
+        const hasDocName = !!documentName?.trim();
+
+        if (!userId || (!hasStartDate && !hasEndDate && !hasVetName && !hasDocName)) {
+            return {
+                statusCode: HttpStatus.OK,
+                message: "Documents retrieved successfully",
+                data: []
+            };
+        }
+
+        let start: Date | undefined;
+        let end: Date | undefined;
+
+        if (hasStartDate) {
+            start = new Date(startDate!);
+            if (isNaN(start.getTime())) {
+                if (!hasEndDate && !hasVetName && !hasDocName) {
+                    return {
+                        statusCode: HttpStatus.OK,
+                        message: "Documents retrieved successfully",
+                        data: []
+                    };
+                }
+                start = undefined;
+            }
+        }
+
+        if (hasEndDate) {
+            end = new Date(endDate!);
+            if (isNaN(end.getTime())) {
+                if (!start && !hasVetName && !hasDocName) {
+                    return {
+                        statusCode: HttpStatus.OK,
+                        message: "Documents retrieved successfully",
+                        data: []
+                    };
+                }
+                end = undefined;
+            }
+        }
+
+        try {
+            const documents = await this.documentRepository.findDocumentsByUserId(userId, {
+                startDate: start,
+                endDate: end,
+                veterinarianName: hasVetName ? veterinarianName?.trim() : undefined,
+                documentName: hasDocName ? documentName?.trim() : undefined,
+            });
+
+            return {
+                statusCode: HttpStatus.OK,
+                message: "Documents retrieved successfully",
+                data: documents
+            };
+        } catch (error) {
+            throw error;
+        }
+    }
+}

--- a/src/modules/document/application/use-cases/index.ts
+++ b/src/modules/document/application/use-cases/index.ts
@@ -2,3 +2,5 @@ export * from "./register-document.use-case";
 export * from "./update-document.use-case";
 export * from "./delete-document.use-case";
 export * from "./get-document-by-id.use-case";
+export * from "./find-documents-by-user-id.use-case";
+

--- a/src/modules/document/document.module.ts
+++ b/src/modules/document/document.module.ts
@@ -5,7 +5,8 @@ import {
     DeleteDocumentUseCase,
     GetDocumentByIdUseCase,
     RegisterDocumentUseCase,
-    UpdateDocumentUseCase
+    UpdateDocumentUseCase,
+    FindDocumentsByUserIdUseCase
 } from "@document/application/use-cases";
 
 @Module({
@@ -19,6 +20,7 @@ import {
         UpdateDocumentUseCase,
         DeleteDocumentUseCase,
         GetDocumentByIdUseCase,
+        FindDocumentsByUserIdUseCase,
     ],
     exports: [
         "IDocumentRepository",
@@ -26,6 +28,7 @@ import {
         UpdateDocumentUseCase,
         DeleteDocumentUseCase,
         GetDocumentByIdUseCase,
+        FindDocumentsByUserIdUseCase,
     ]
 })
 export class DocumentModule { }

--- a/src/modules/document/domain/models/document.model.ts
+++ b/src/modules/document/domain/models/document.model.ts
@@ -28,3 +28,11 @@ export interface RegisterDocumentModel {
 }
 
 export interface UpdateDocumentModel extends Partial<RegisterDocumentModel> { }
+
+export interface FindDocumentsCriteria {
+    startDate?: Date;
+    endDate?: Date;
+    veterinarianName?: string;
+    documentName?: string;
+}
+

--- a/src/modules/document/domain/ports/document.repository.ts
+++ b/src/modules/document/domain/ports/document.repository.ts
@@ -1,8 +1,9 @@
-import { DocumentModel, RegisterDocumentModel, UpdateDocumentModel } from "@document/domain/models";
+import { DocumentModel, RegisterDocumentModel, UpdateDocumentModel, FindDocumentsCriteria } from "@document/domain/models";
 
 export interface IDocumentRepository {
     registerDocument(document: RegisterDocumentModel): Promise<string>;
     updateDocument(document: UpdateDocumentModel, id: string): Promise<string>;
     deleteDocument(id: string): Promise<string>;
     getDocumentById(id: string): Promise<DocumentModel>;
+    findDocumentsByUserId(userId: string, criteria: FindDocumentsCriteria): Promise<DocumentModel[]>;
 }

--- a/src/modules/document/infrastructure/persistance/document.service.spec.ts
+++ b/src/modules/document/infrastructure/persistance/document.service.spec.ts
@@ -1,11 +1,11 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { DocumentService } from '@document/infrastructure/document.service';
+import { PrismaDocumentService } from '@document/infrastructure/persistance/prisma-document.service';
 import { PrismaService } from '@/common/infrastructure/db/prisma.service';
-import { RegisterDocumentDto, UpdateDocumentDto } from '@document/infrastructure/dto';
+import { DocumentModel, RegisterDocumentModel, UpdateDocumentModel, FindDocumentsCriteria } from '@document/domain/models';
 import { DocumentFileUrlNotFoundException, DocumentIdNotFoundException, DocumentTitleNotFoundException } from '@document/domain/exceptions';
 
-describe('DocumentService', () => {
-    let service: DocumentService;
+describe('PrismaDocumentService', () => {
+    let service: PrismaDocumentService;
     let prisma: PrismaService;
 
     const mockPrismaService = {
@@ -14,13 +14,14 @@ describe('DocumentService', () => {
             update: jest.fn(),
             delete: jest.fn(),
             findUnique: jest.fn(),
+            findMany: jest.fn(),
         },
     };
 
     beforeEach(async () => {
         const module: TestingModule = await Test.createTestingModule({
             providers: [
-                DocumentService,
+                PrismaDocumentService,
                 {
                     provide: PrismaService,
                     useValue: mockPrismaService,
@@ -28,7 +29,7 @@ describe('DocumentService', () => {
             ],
         }).compile();
 
-        service = module.get<DocumentService>(DocumentService);
+        service = module.get<PrismaDocumentService>(PrismaDocumentService);
         prisma = module.get<PrismaService>(PrismaService);
     });
 
@@ -41,7 +42,7 @@ describe('DocumentService', () => {
     });
 
     describe('registerDocument', () => {
-        const registerDocumentDto: RegisterDocumentDto = {
+        const registerDocumentModel: RegisterDocumentModel = {
             title: 'Test Document',
             fileUrl: 'http://example.com/file.pdf',
             category: 'MEDICAL_REPORT',
@@ -49,49 +50,43 @@ describe('DocumentService', () => {
         };
 
         it('should register a document successfully', async () => {
-            mockPrismaService.document.create.mockResolvedValue({ id: 'doc-123', ...registerDocumentDto });
+            mockPrismaService.document.create.mockResolvedValue({ id: 'doc-123', ...registerDocumentModel });
 
-            const result = await service.registerDocument(registerDocumentDto);
+            const result = await service.registerDocument(registerDocumentModel);
 
             expect(prisma.document.create).toHaveBeenCalled();
-            expect(result).toEqual({
-                statusCode: 201,
-                message: 'Document registered successfully',
-            });
+            expect(result).toEqual('doc-123');
         });
 
         it('should throw DocumentTitleNotFoundException if title is missing', async () => {
-            const dto = { ...registerDocumentDto, title: '' } as RegisterDocumentDto;
-            await expect(service.registerDocument(dto)).rejects.toThrow(DocumentTitleNotFoundException);
+            const model = { ...registerDocumentModel, title: '' } as RegisterDocumentModel;
+            await expect(service.registerDocument(model)).rejects.toThrow(DocumentTitleNotFoundException);
         });
 
         it('should throw DocumentFileUrlNotFoundException if fileUrl is missing', async () => {
-            const dto = { ...registerDocumentDto, fileUrl: '' } as RegisterDocumentDto;
-            await expect(service.registerDocument(dto)).rejects.toThrow(DocumentFileUrlNotFoundException);
+            const model = { ...registerDocumentModel, fileUrl: '' } as RegisterDocumentModel;
+            await expect(service.registerDocument(model)).rejects.toThrow(DocumentFileUrlNotFoundException);
         });
     });
 
     describe('updateDocument', () => {
         const docId = 'doc-123';
-        const updateDocumentDto: UpdateDocumentDto = { title: 'Updated Title' };
+        const updateDocumentModel: UpdateDocumentModel = { title: 'Updated Title' };
 
         it('should update a document successfully', async () => {
-            mockPrismaService.document.update.mockResolvedValue({ id: docId, ...updateDocumentDto });
+            mockPrismaService.document.update.mockResolvedValue({ id: docId, ...updateDocumentModel });
 
-            const result = await service.updateDocument(updateDocumentDto, docId);
+            const result = await service.updateDocument(updateDocumentModel, docId);
 
             expect(prisma.document.update).toHaveBeenCalledWith({
                 where: { id: docId },
-                data: updateDocumentDto,
+                data: updateDocumentModel,
             });
-            expect(result).toEqual({
-                statusCode: 200,
-                message: 'Document updated successfully',
-            });
+            expect(result).toEqual(docId);
         });
 
         it('should throw DocumentIdNotFoundException if id is missing', async () => {
-            await expect(service.updateDocument(updateDocumentDto, '')).rejects.toThrow(DocumentIdNotFoundException);
+            await expect(service.updateDocument(updateDocumentModel, '')).rejects.toThrow(DocumentIdNotFoundException);
         });
     });
 
@@ -104,10 +99,7 @@ describe('DocumentService', () => {
             const result = await service.deleteDocument(docId);
 
             expect(prisma.document.delete).toHaveBeenCalledWith({ where: { id: docId } });
-            expect(result).toEqual({
-                statusCode: 200,
-                message: 'Document deleted successfully',
-            });
+            expect(result).toEqual(docId);
         });
 
         it('should throw DocumentIdNotFoundException if id is missing', async () => {
@@ -129,10 +121,7 @@ describe('DocumentService', () => {
             const result = await service.getDocumentById(docId);
 
             expect(prisma.document.findUnique).toHaveBeenCalledWith({ where: { id: docId } });
-            expect(result).toEqual({
-                statusCode: 200,
-                data: mockDoc,
-            });
+            expect(result).toEqual(mockDoc);
         });
 
         it('should throw DocumentIdNotFoundException if id is missing', async () => {
@@ -142,6 +131,63 @@ describe('DocumentService', () => {
         it('should throw DocumentIdNotFoundException if document is not found', async () => {
             mockPrismaService.document.findUnique.mockResolvedValue(null);
             await expect(service.getDocumentById(docId)).rejects.toThrow(DocumentIdNotFoundException);
+        });
+    });
+
+    describe('findDocumentsByUserId', () => {
+        const userId = 'user-123';
+        const criteria: FindDocumentsCriteria = {
+            startDate: new Date('2026-01-01'),
+            endDate: new Date('2026-12-31'),
+            veterinarianName: 'John',
+            documentName: 'Report',
+        };
+
+        it('should find documents by user id and criteria', async () => {
+            const mockDocs = [
+                { id: 'doc-1', title: 'Report 1', fileUrl: 'http://example.com/1.pdf' },
+            ];
+            mockPrismaService.document.findMany.mockResolvedValue(mockDocs);
+
+            const result = await service.findDocumentsByUserId(userId, criteria);
+
+            expect(prisma.document.findMany).toHaveBeenCalledWith({
+                where: {
+                    createdAt: {
+                        gte: criteria.startDate,
+                        lte: criteria.endDate,
+                    },
+                    title: {
+                        contains: criteria.documentName,
+                        mode: 'insensitive',
+                    },
+                    medicalRecord: {
+                        veterinarian: {
+                            user: {
+                                name: {
+                                    contains: criteria.veterinarianName,
+                                    mode: 'insensitive',
+                                },
+                            },
+                        },
+                        OR: [
+                            {
+                                pet: {
+                                    owner: {
+                                        userId: userId,
+                                    },
+                                },
+                            },
+                            {
+                                veterinarian: {
+                                    userId: userId,
+                                },
+                            },
+                        ],
+                    },
+                },
+            });
+            expect(result).toEqual(mockDocs);
         });
     });
 });

--- a/src/modules/document/infrastructure/persistance/prisma-document.service.ts
+++ b/src/modules/document/infrastructure/persistance/prisma-document.service.ts
@@ -1,7 +1,7 @@
 import { HttpStatus, Injectable } from "@nestjs/common";
 import { PrismaService } from "@/common/infrastructure/db";
 import { DocumentFileUrlNotFoundException, DocumentIdNotFoundException, DocumentTitleNotFoundException } from "@document/domain/exceptions";
-import { DocumentModel, RegisterDocumentModel, UpdateDocumentModel } from "@document/domain/models";
+import { DocumentModel, RegisterDocumentModel, UpdateDocumentModel, FindDocumentsCriteria } from "@document/domain/models";
 import { IDocumentRepository } from "@document/domain/ports/document.repository";
 
 @Injectable()
@@ -66,4 +66,57 @@ export class PrismaDocumentService implements IDocumentRepository {
 
         return document;
     }
+
+    async findDocumentsByUserId(userId: string, criteria: FindDocumentsCriteria): Promise<DocumentModel[]> {
+        const { startDate, endDate, veterinarianName, documentName } = criteria;
+
+        const whereClause: any = {
+            medicalRecord: {
+                OR: [
+                    {
+                        pet: {
+                            owner: {
+                                userId: userId,
+                            },
+                        },
+                    },
+                    {
+                        veterinarian: {
+                            userId: userId,
+                        },
+                    },
+                ],
+            },
+        };
+
+        if (startDate || endDate) {
+            const dateFilter: any = {};
+            if (startDate) dateFilter.gte = startDate;
+            if (endDate) dateFilter.lte = endDate;
+            whereClause.createdAt = dateFilter;
+        }
+
+        if (documentName) {
+            whereClause.title = {
+                contains: documentName,
+                mode: 'insensitive',
+            };
+        }
+
+        if (veterinarianName) {
+            whereClause.medicalRecord.veterinarian = {
+                user: {
+                    name: {
+                        contains: veterinarianName,
+                        mode: 'insensitive',
+                    },
+                },
+            };
+        }
+
+        return this.prisma.document.findMany({
+            where: whereClause,
+        });
+    }
 }
+

--- a/src/modules/document/presentation/document.controller.spec.ts
+++ b/src/modules/document/presentation/document.controller.spec.ts
@@ -4,7 +4,8 @@ import {
     DeleteDocumentUseCase,
     GetDocumentByIdUseCase,
     RegisterDocumentUseCase,
-    UpdateDocumentUseCase
+    UpdateDocumentUseCase,
+    FindDocumentsByUserIdUseCase
 } from '@document/application/use-cases';
 import { RegisterDocumentRequestDto, UpdateDocumentDto } from '@document/presentation/dtos';
 import { UploadFileCommand } from '@/common/upload/application/use-cases';
@@ -29,6 +30,7 @@ describe('DocumentController', () => {
     const mockUpdateUseCase = { execute: jest.fn() };
     const mockDeleteUseCase = { execute: jest.fn() };
     const mockGetByIdUseCase = { execute: jest.fn() };
+    const mockFindDocumentsByUserIdUseCase = { execute: jest.fn() };
 
     beforeEach(async () => {
         const module: TestingModule = await Test.createTestingModule({
@@ -38,6 +40,7 @@ describe('DocumentController', () => {
                 { provide: UpdateDocumentUseCase, useValue: mockUpdateUseCase },
                 { provide: DeleteDocumentUseCase, useValue: mockDeleteUseCase },
                 { provide: GetDocumentByIdUseCase, useValue: mockGetByIdUseCase },
+                { provide: FindDocumentsByUserIdUseCase, useValue: mockFindDocumentsByUserIdUseCase },
             ],
         }).compile();
 
@@ -75,7 +78,6 @@ describe('DocumentController', () => {
                 fileKey: 'file-key',
                 fileSize: 1024,
                 fileType: 'application/pdf',
-                userId: expect.any(String),
             }));
             expect(result).toEqual({
                 statusCode: 201,
@@ -139,5 +141,35 @@ describe('DocumentController', () => {
             });
         });
     });
+
+    describe('findDocumentsByUserId', () => {
+        it('should call findDocumentsByUserIdUseCase.execute', async () => {
+            const userId = 'user-123';
+            const queries = {
+                startDate: '2026-01-01',
+                endDate: '2026-12-31',
+                veterinarianName: 'John Doe',
+                documentName: 'Report',
+            };
+            const mockResult = {
+                statusCode: 200,
+                message: 'Documents retrieved successfully',
+                data: [],
+            };
+            mockFindDocumentsByUserIdUseCase.execute.mockResolvedValue(mockResult);
+
+            const result = await controller.findDocumentsByUserId(
+                userId,
+                queries.startDate,
+                queries.endDate,
+                queries.veterinarianName,
+                queries.documentName,
+            );
+
+            expect(mockFindDocumentsByUserIdUseCase.execute).toHaveBeenCalledWith(userId, queries);
+            expect(result).toEqual(mockResult);
+        });
+    });
 });
+
 

--- a/src/modules/document/presentation/document.controller.ts
+++ b/src/modules/document/presentation/document.controller.ts
@@ -1,10 +1,11 @@
-import { Body, Controller, Delete, Get, Param, Post, Put, UploadedFile, UseInterceptors } from "@nestjs/common";
+import { Body, Controller, Delete, Get, Param, Post, Put, Query, UploadedFile, UseInterceptors } from "@nestjs/common";
 import { RegisterDocumentRequestDto, UpdateDocumentDto } from "@document/presentation/dtos";
 import { UploadFileCommand } from "@/common/upload/application/use-cases";
 import { FolderUploadTypes, UploadPlatformEnum } from "@/common/upload/domain/enums";
 import { FileInterceptor } from "@nestjs/platform-express";
 import {
     DeleteDocumentUseCase,
+    FindDocumentsByUserIdUseCase,
     GetDocumentByIdUseCase,
     RegisterDocumentUseCase,
     UpdateDocumentUseCase
@@ -17,6 +18,7 @@ export class DocumentController {
         private readonly updateDocumentUseCase: UpdateDocumentUseCase,
         private readonly deleteDocumentUseCase: DeleteDocumentUseCase,
         private readonly getDocumentByIdUseCase: GetDocumentByIdUseCase,
+        private readonly findDocumentsByUserIdUseCase: FindDocumentsByUserIdUseCase,
     ) { }
 
     @Post("register")
@@ -46,6 +48,22 @@ export class DocumentController {
     @Get(":id")
     async getDocumentById(@Param("id") id: string) {
         return this.getDocumentByIdUseCase.execute(id);
+    }
+
+    @Get("user/:userId")
+    async findDocumentsByUserId(
+        @Param("userId") userId: string,
+        @Query("startDate") startDate?: string,
+        @Query("endDate") endDate?: string,
+        @Query("veterinarianName") veterinarianName?: string,
+        @Query("documentName") documentName?: string,
+    ) {
+        return this.findDocumentsByUserIdUseCase.execute(userId, {
+            startDate,
+            endDate,
+            veterinarianName,
+            documentName,
+        });
     }
 }
 


### PR DESCRIPTION
…al filters

- Implement ability to retrieve documents via either ownerId -> pet -> medicalRecord -> documents or veterinarian -> medicalRecord -> documents based on userId.

- Support dynamic query filters: date range, veterinarian's name, and matching document name.

- Return an empty array immediately if no search query parameters are provided.

- Implement FindDocumentsByUserIdUseCase, update IDocumentRepository and PrismaDocumentService.

- Add unit and integration tests for the new query logic.